### PR TITLE
Specify YAML loader encoding to utf-8.

### DIFF
--- a/vendor/vfi_utils.py
+++ b/vendor/vfi_utils.py
@@ -22,7 +22,7 @@ BASE_MODEL_DOWNLOAD_URLS = [
 
 config_path = os.path.join(os.path.dirname(__file__), "./config.yaml")
 if os.path.exists(config_path):
-    config = yaml.load(open(config_path, "r"), Loader=yaml.FullLoader)
+    config = yaml.load(open(config_path, "r", encoding="utf-8"), Loader=yaml.FullLoader)
 else:
     raise Exception(
         "config.yaml file is neccessary, plz recreate the config file by downloading it from https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"


### PR DESCRIPTION
Fix this issue on my termial where "gbk" is the default code page:

```
Traceback (most recent call last):
  File "D:\Repos\ComfyUI\nodes.py", line 2131, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "D:\Repos\ComfyUI\custom_nodes\comfyui-WhiteRabbit\__init__.py", line 4, in <module>
    from .interpolation import (
  File "D:\Repos\ComfyUI\custom_nodes\comfyui-WhiteRabbit\interpolation.py", line 47, in <module>
    from rife import CKPT_NAME_VER_DICT, MODEL_TYPE
  File "D:\Repos\ComfyUI\custom_nodes\comfyui-WhiteRabbit\vendor\rife\__init__.py", line 6, in <module>
    from vfi_utils import (
  File "D:\Repos\ComfyUI\custom_nodes\comfyui-WhiteRabbit\vendor\vfi_utils.py", line 25, in <module>
    config = yaml.load(open(config_path, "r"), Loader=yaml.FullLoader)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Minghao\AppData\Local\Programs\Python\Python312\Lib\site-packages\yaml\__init__.py", line 79, in load
    loader = Loader(stream)
             ^^^^^^^^^^^^^^
  File "C:\Users\Minghao\AppData\Local\Programs\Python\Python312\Lib\site-packages\yaml\loader.py", line 24, in __init__
    Reader.__init__(self, stream)
  File "C:\Users\Minghao\AppData\Local\Programs\Python\Python312\Lib\site-packages\yaml\reader.py", line 85, in __init__
    self.determine_encoding()
  File "C:\Users\Minghao\AppData\Local\Programs\Python\Python312\Lib\site-packages\yaml\reader.py", line 124, in determine_encoding
    self.update_raw()
  File "C:\Users\Minghao\AppData\Local\Programs\Python\Python312\Lib\site-packages\yaml\reader.py", line 178, in update_raw
    data = self.stream.read(size)
           ^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 24: illegal multibyte sequence
```